### PR TITLE
Issue/54

### DIFF
--- a/Alien.js
+++ b/Alien.js
@@ -27,6 +27,7 @@ function Alien(descr) {
   this.velY = 0.5;
   this.acceleration = 0;
   this.maxAcceleration = 3;
+  this.sidePush = 2;
   this.velX = 0.1;
   this.accelerationY = 0;
   this.dir = 1;
@@ -203,9 +204,9 @@ Alien.prototype.maybeAttack = function() {
       this.isAttacking = true;
       this.accelerationY = -2;
       this.dir = 1;
-      this.acceleration = this.maxAcceleration;
+      this.acceleration = this.sidePush;
       if(leftNeighboursDead)
-        this.acceleration = - this.maxAcceleration;
+        this.acceleration = - this.sidePush;
         this.dir = -1;
     }
   }

--- a/entityManager.js
+++ b/entityManager.js
@@ -181,11 +181,52 @@ updateAlienPosition : function(du) {
     for(let i = 0; i < this._aliens_x_position.length; i++){
         let direction = this.getAliensDirection();
         let nextX = this._aliens_x_position[i] + (velX * direction * du);
-        if (nextX < halfWidth || nextX > g_canvas.width - halfWidth) {
-            this.changeAliensDirection();
-        }
+        //if (nextX < halfWidth + 30 || nextX > g_canvas.width - halfWidth - 30) {
+        //    this.changeAliensDirection();
+        //}
         this._aliens_x_position[i] = nextX;
     }
+
+    // Check which column is closest to the left and right
+    let alienGrid = this.getAlienGrid();
+    let closestLeft = alienGrid[0].length;
+    let closestRight = 0;
+    for(let col = 0; col < alienGrid[0].length; col++){
+        let found = false;
+        for(let row = 0; row < alienGrid.length; row++){
+            if(alienGrid[row][col] != 0){
+                found = true;
+                break;
+            }
+        }
+        if(found == true){
+            closestLeft = col;
+            break;
+        }
+    }
+    for(let col = alienGrid[0].length - 1; col >= 0; col--){
+        let found = false;
+        for(let row = 0; row < alienGrid.length; row++){
+            if(alienGrid[row][col] != 0){
+                found = true;
+                break;
+            }
+        }
+        if(found == true){
+            closestRight = col;
+            break;
+        }
+    }
+
+    // If the enemy most left or most right is close to the border, change enemy directions
+    let alienLeftX = this._aliens_x_position[closestLeft];
+    let alienRightX = this._aliens_x_position[closestRight]; 
+    if(alienLeftX < 25 || alienRightX > g_canvas.width - 25)
+        this.changeAliensDirection();
+    //if (nextX < halfWidth + 30 || nextX > g_canvas.width - halfWidth - 30) {
+    //    this.changeAliensDirection();
+    //}
+
 },
 
 // Get the grid that is used to check if neighbouring aliens is alive

--- a/entityManager.js
+++ b/entityManager.js
@@ -220,8 +220,9 @@ updateAlienPosition : function(du) {
 
     // If the enemy most left or most right is close to the border, change enemy directions
     let alienLeftX = this._aliens_x_position[closestLeft];
-    let alienRightX = this._aliens_x_position[closestRight]; 
-    if(alienLeftX < 25 || alienRightX > g_canvas.width - 25)
+    let alienRightX = this._aliens_x_position[closestRight];
+    let border = 50; 
+    if(alienLeftX < border || alienRightX > g_canvas.width - border)
         this.changeAliensDirection();
     //if (nextX < halfWidth + 30 || nextX > g_canvas.width - halfWidth - 30) {
     //    this.changeAliensDirection();


### PR DESCRIPTION
The alien grid changes direction based on the aliens furthest out to the left and not a middle point. This creates the effect that when the grid gets smaller by enemy dying, it will still move all the way out to the borders.

This also fixes so the alien doesn't go as far to the side when starting attack run.

Resolves #54 
